### PR TITLE
Implement Longstaff-Schwartz swing option pricer

### DIFF
--- a/src/lsm_swing_pricer.py
+++ b/src/lsm_swing_pricer.py
@@ -1,0 +1,132 @@
+"""Least-squares Monte Carlo pricer for swing options."""
+
+from typing import Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+from .swing_contract import SwingContract
+
+
+def _regress(X: np.ndarray, y: np.ndarray, degree: int, mask: Optional[np.ndarray] = None) -> np.ndarray:
+    """Return fitted values of polynomial regression."""
+    if mask is not None and mask.sum() >= degree + 1:
+        Xm = X[mask]
+        ym = y[mask]
+    else:
+        Xm = X
+        ym = y
+    beta, *_ = np.linalg.lstsq(Xm, ym, rcond=None)
+    return X @ beta
+
+
+def price_swing_option_lsm(
+    contract: SwingContract,
+    dataset: Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    poly_degree: int = 2,
+    n_bootstrap: int = 1000,
+    seed: Optional[int] = None,
+    csv_path: str = "swing_option_lsm_paths.csv",
+) -> Tuple[float, Tuple[float, float]]:
+    """Price swing option using the Longstaff–Schwartz method.
+
+    Parameters
+    ----------
+    contract : SwingContract
+        Swing option contract specifications.
+    dataset : tuple
+        Tuple ``(t, S, X, Y)`` with simulated spot price paths ``S`` of
+        shape ``(n_paths, n_steps + 1)``.
+    poly_degree : int, optional
+        Degree of polynomial basis used in regressions.
+    n_bootstrap : int, optional
+        Number of bootstrap samples for confidence interval.
+    seed : int, optional
+        Random seed for bootstrap.
+    csv_path : str, optional
+        Destination for CSV log of optimal exercises.
+    """
+    t, S, _, _ = dataset
+    prices = S[:, 1:]  # decision prices (exclude initial spot)
+    n_paths, n_steps = prices.shape
+    assert n_steps == contract.n_rights, "Mismatch between paths and contract rights"
+
+    df = contract.discount_factor
+    strike = contract.strike
+    qmax = contract.q_max
+
+    # number of discrete rights (assumes Q_max multiple of q_max)
+    R = int(round(contract.Q_max / qmax))
+
+    values = np.zeros((R + 1, n_paths))
+    exercise = np.zeros((R + 1, n_paths, n_steps), dtype=bool)
+
+    payoff_T = qmax * np.maximum(prices[:, -1] - strike, 0.0)
+    itm_T = prices[:, -1] > strike
+    for r in range(1, R + 1):
+        values[r] = payoff_T
+        exercise[r, itm_T, n_steps - 1] = True
+
+    X_poly = np.empty((n_paths, poly_degree + 1))
+
+    for j in range(n_steps - 2, -1, -1):
+        price = prices[:, j]
+        payoff = qmax * np.maximum(price - strike, 0.0)
+        X_poly[:, 0] = 1.0
+        for k in range(1, poly_degree + 1):
+            X_poly[:, k] = price ** k
+        mask = payoff > 0
+        old_vals = values.copy()
+        new_vals = values.copy()
+        for r in range(1, R + 1):
+            y_keep = df * old_vals[r]
+            y_ex = df * old_vals[r - 1]
+            cont_keep = _regress(X_poly, y_keep, poly_degree, mask)
+            cont_ex = _regress(X_poly, y_ex, poly_degree, mask)
+            exc = (payoff + cont_ex > cont_keep) & (payoff > 0)
+            exercise[r, exc, j] = True
+            new_vals[r] = np.where(exc, payoff + y_ex, y_keep)
+        values = new_vals
+
+    rights = np.full(n_paths, R, dtype=int)
+    q_used = np.zeros(n_paths)
+    path_payoffs = np.zeros(n_paths)
+    records = []
+    for j in range(n_steps):
+        price = prices[:, j]
+        disc = df ** (j + 1)
+        for i in range(n_paths):
+            r = rights[i]
+            q_before = q_used[i]
+            if r > 0 and exercise[r, i, j]:
+                q = min(qmax, contract.Q_max - q_before)
+                pay = q * max(price[i] - strike, 0.0)
+                rights[i] -= 1
+                q_used[i] += q
+                path_payoffs[i] += disc * pay
+            else:
+                q = 0.0
+                pay = 0.0
+            records.append({
+                "path": i,
+                "time_step": j,
+                "spot": price[i],
+                "q_exercised_so_far": q_before,
+                "q_t": q,
+                "payoff": pay,
+            })
+    pd.DataFrame(records).to_csv(csv_path, index=False)
+
+    price_estimate = path_payoffs.mean()
+    rng = np.random.default_rng(seed)
+    boot_means = np.empty(n_bootstrap)
+    for b in range(n_bootstrap):
+        idx = rng.integers(0, n_paths, n_paths)
+        boot_means[b] = path_payoffs[idx].mean()
+    ci_low, ci_high = np.percentile(boot_means, [2.5, 97.5])
+
+    print(
+        f"Swing option price: {price_estimate:.4f}\n"
+        f"95% CI: [{ci_low:.4f}, {ci_high:.4f}]"
+    )
+    return price_estimate, (ci_low, ci_high)

--- a/tests/test_lsm_pricer.py
+++ b/tests/test_lsm_pricer.py
@@ -1,0 +1,58 @@
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.append(os.path.abspath('.'))
+from src.swing_contract import SwingContract
+from src.lsm_swing_pricer import price_swing_option_lsm
+
+def build_dataset(S0: float, future: np.ndarray, T: float) -> tuple:
+    n_paths, n_steps = future.shape
+    S = np.concatenate([np.full((n_paths,1), S0), future], axis=1)
+    t = np.linspace(0.0, T, n_steps + 1)
+    X = np.zeros_like(S)
+    Y = np.zeros_like(S)
+    return t, S, X, Y
+
+def test_constant_in_the_money(tmp_path):
+    contract = SwingContract(q_min=0.0, q_max=1.0, Q_min=0.0, Q_max=2.0,
+                             strike=1.0, maturity=2.0, n_rights=2, r=0.0)
+    future = np.full((1, contract.n_rights), 2.0)
+    dataset = build_dataset(2.0, future, contract.maturity)
+    price, _ = price_swing_option_lsm(contract, dataset, poly_degree=1,
+                                     n_bootstrap=100, seed=0,
+                                     csv_path=str(tmp_path/'res.csv'))
+    assert np.isclose(price, 2.0, atol=1e-6)
+    df = pd.read_csv(tmp_path/'res.csv')
+    assert df['q_t'].sum() == pytest.approx(2.0)
+
+def test_out_of_the_money(tmp_path):
+    contract = SwingContract(q_min=0.0, q_max=1.0, Q_min=0.0, Q_max=2.0,
+                             strike=1.0, maturity=2.0, n_rights=2, r=0.0)
+    future = np.full((1, contract.n_rights), 0.5)
+    dataset = build_dataset(0.5, future, contract.maturity)
+    price, _ = price_swing_option_lsm(contract, dataset, poly_degree=1,
+                                     n_bootstrap=100, seed=1,
+                                     csv_path=str(tmp_path/'res.csv'))
+    assert np.isclose(price, 0.0, atol=1e-6)
+    df = pd.read_csv(tmp_path/'res.csv')
+    assert df['q_t'].sum() == pytest.approx(0.0)
+
+def test_large_monthly_dataset(tmp_path):
+    contract = SwingContract(q_min=0.0, q_max=2.0, Q_min=0.0, Q_max=20.0,
+                             strike=1.0, maturity=0.0833, n_rights=22, r=0.05)
+    n_paths = 16000
+    rng = np.random.default_rng(0)
+    dt = contract.maturity / contract.n_rights
+    increments = rng.normal(scale=0.2*np.sqrt(dt), size=(n_paths, contract.n_rights))
+    future = np.exp(np.log(contract.strike) + np.cumsum(increments, axis=1))
+    dataset = build_dataset(contract.strike, future, contract.maturity)
+    price, ci = price_swing_option_lsm(contract, dataset, poly_degree=2,
+                                       n_bootstrap=100, seed=2,
+                                       csv_path=str(tmp_path/'res.csv'))
+    assert np.isfinite(price)
+    assert ci[1] >= ci[0]
+    assert (tmp_path/'res.csv').exists()


### PR DESCRIPTION
## Summary
- implement Longstaff-Schwartz Monte Carlo pricer for swing options with polynomial regression, bootstrap confidence intervals, and CSV logging
- add comprehensive tests including deterministic checks and large monthly configuration

## Testing
- `pytest tests/test_lsm_pricer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f49b035cc833397a8730d60ffa82b