### PR TITLE
fix(ci): remove unsupported setup-miniconda cache inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,6 @@ jobs:
           activate-environment: EP11
           miniforge-version: latest
           use-mamba: true
-          cache-environment: true          # cache the solved env by environment.yml hash
-          cache-environment-key: conda-${{ runner.os }}-${{ hashFiles('environment.yml') }}
 
       - name: Show environment
         run: |


### PR DESCRIPTION
Removes `cache-environment` / `cache-environment-key` which are not valid inputs for this version of `conda-incubator/setup-miniconda@v3` (they caused a noisy warning on every CI run). Env caching can be re-added when using a compatible action version. CI is already green without them.